### PR TITLE
feat(release): add more release types

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,17 @@
 {
   "branches": ["+([0-9])?(.{+([0-9]),x}).x", "master", {"name": "beta", "prerelease": true}, {"name": "alpha", "prerelease": true}],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "docs", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "scope": "no-release", "release": false }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/git",


### PR DESCRIPTION
## What this PR changes/adds

This PR adds "docs" and "refactor" as new release types and new scope "no-release" to skip a release.

## Why it does that

To enhance the CHANGELOG.md

## Further notes

https://github.com/semantic-release/commit-analyzer#usage