### PR TITLE
fix: removed workingdir since cd is used

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -58,9 +58,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     if: ${{ needs.release.outputs.new_tag_version != '' }}
-    defaults:
-        run:
-          working-directory: ./clearing-house-edc
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## What this PR changes/adds

Removes ```working-directory``` from the docker build job for the ch-edc image.

## Why it does that

The cmd itself uses ```cd``` already

## Linked Issue(s)

Closes #74 